### PR TITLE
V060 solicitudes fixes

### DIFF
--- a/src/app/features/dashboard-estatal/dashboard-estatal-page.component.html
+++ b/src/app/features/dashboard-estatal/dashboard-estatal-page.component.html
@@ -1,6 +1,6 @@
 <div class="space-y-4">
       <section class="p-4 bg-white rounded-2xl border-gray-100 shadow-sm border">
-        <div class="flex flex-col gap-3 mb-3 sm:flex-row items-center justify-between">
+        <div class="flex flex-col items-center justify-between gap-3 mb-3 sm:flex-row">
           <div class="text-sm text-gray-500">
             <p class="font-semibold text-gray-800">Priorización por clave</p>
             <p>Órdenes emitidas en los últimos {{ windowDays() }} días</p>
@@ -8,7 +8,7 @@
 
           <button
             type="button"
-            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-emerald-700 rounded-xl hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-60"
+            class="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-emerald-700 rounded-xl cursor-pointer hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-60"
             [disabled]="loadingTop() || exportingExcel()"
             (click)="exportarExcel()">
             <lucide-angular [img]="DownloadIcon" class="h-4 w-4"></lucide-angular>
@@ -80,7 +80,7 @@
             <div class="h-24 bg-gray-100 rounded-2xl"></div>
           </div>
         } @else if (resumen(); as row) {
-          <div class="flex flex-col gap-2 mb-4 lg:flex-row items-start justify-between">
+          <div class="flex flex-col items-start justify-between gap-2 mb-4 lg:flex-row">
             <div>
               <p class="text-xs font-semibold tracking-wide text-emerald-700 uppercase">Clave seleccionada</p>
               <h2 class="text-xl font-bold text-gray-900">{{ row.clave_cnis }}</h2>

--- a/src/app/features/dashboard-estatal/dashboard-estatal-page.component.ts
+++ b/src/app/features/dashboard-estatal/dashboard-estatal-page.component.ts
@@ -35,6 +35,7 @@ export class DashboardEstatalPageComponent {
   private dashboardEstatalService = inject(DashboardEstatalService);
   private destroyRef = inject(DestroyRef);
   private searchTerms = new Subject<string>();
+  private readonly excelFaltantesLimit = 10000;
 
   readonly SearchIcon = Search;
   readonly DownloadIcon = Download;
@@ -190,12 +191,17 @@ export class DashboardEstatalPageComponent {
     this.errorExport.set(null);
 
     try {
+      const faltantesParaExport = await this.cargarFaltantesParaExport();
       const [ordenesFaltantes, ordenesSobreabasto] = await Promise.all([
-        this.cargarOrdenesParaExport(this.topFaltantes()),
+        this.cargarOrdenesParaExport(faltantesParaExport),
         this.cargarOrdenesParaExport(this.topSobreabasto()),
       ]);
 
       const notas: string[] = [];
+      notas.push('La hoja de faltantes incluye claves con CPMs equivalentes >= 0 y < 1, solicitadas al backend con un limite amplio para exportacion.');
+      if (faltantesParaExport.length >= this.excelFaltantesLimit) {
+        notas.push(`El listado de faltantes llego al limite de ${this.excelFaltantesLimit} registros; podria requerir un endpoint paginado/dedicado para garantizar universo completo.`);
+      }
       if (ordenesFaltantes.errorCount + ordenesSobreabasto.errorCount > 0) {
         notas.push('No se pudieron cargar algunas órdenes pendientes. Verifica que el endpoint /dashboard-estatal/ordenes-pendientes esté disponible en backend.');
       }
@@ -205,7 +211,7 @@ export class DashboardEstatalPageComponent {
         `Dashboard_Estatal_${this.dateStamp()}.xlsx`,
         {
           windowDays: this.windowDays(),
-          topFaltantes: this.topFaltantes(),
+          topFaltantes: faltantesParaExport,
           topSobreabasto: this.topSobreabasto(),
           ordenesFaltantes: ordenesFaltantes.rows,
           ordenesSobreabasto: ordenesSobreabasto.rows,
@@ -269,6 +275,20 @@ export class DashboardEstatalPageComponent {
       rows: responses.flatMap(response => response.rows),
       errorCount: responses.filter(response => response.failed).length,
     };
+  }
+
+  private async cargarFaltantesParaExport(): Promise<DashboardEstatalResumenClave[]> {
+    const response = await firstValueFrom(
+      this.dashboardEstatalService.obtenerTop(this.windowDays(), this.excelFaltantesLimit)
+    );
+
+    return (response.data?.top_faltantes ?? [])
+      .filter(row => this.esFaltantePorCpmsEquivalentes(row));
+  }
+
+  private esFaltantePorCpmsEquivalentes(row: DashboardEstatalResumenClave): boolean {
+    const cpmsEquivalentes = Number(row.cpms_equivalentes);
+    return Number.isFinite(cpmsEquivalentes) && cpmsEquivalentes >= 0 && cpmsEquivalentes < 1;
   }
 
   private dateStamp(): string {

--- a/src/app/features/solicitudes/solicitudes.component.html
+++ b/src/app/features/solicitudes/solicitudes.component.html
@@ -155,7 +155,7 @@
         <div class="mt-4 p-2 border rounded" [hidden]="!articulosSolicitados || articulosSolicitados.length===0">
           <app-tabla-articulos [articulosSolicitados]="articulosSolicitados" [modoEdicionIndex]="modoEdicionIndex"
             [cluesimbActual]="cluesimbActual" [cantidadTemporal]="cantidadTemporal"
-            (cantidadTemporalChange)="cambiarCantidad($event)" [inventario]="inventarioDisponible"
+            [capturaStats]="capturaStats" (cantidadTemporalChange)="cambiarCantidad($event)" [inventario]="inventarioDisponible"
             (confirmar)="confirmarEdicion($event)" (cancelar)="cancelarEdicion()" (editar)="activarEdicion($event)"
             (eliminar)="eliminarArticuloConConfirmacion($event)"
             (CPMsPorUnidadActualizado)="actualizarCPMsPorUnidad($event)" />

--- a/src/app/features/solicitudes/solicitudes.component.ts
+++ b/src/app/features/solicitudes/solicitudes.component.ts
@@ -182,12 +182,14 @@ export class SolicitudesComponent implements OnInit, AfterViewInit, OnDestroy {
       total: this.articulosSolicitados.length,
       cpmCero: 0,
       menorCpm: 0,
+      igualCpm: 0,
       mayorCpm: 0
     };
 
     for (const art of this.articulosSolicitados) {
       const clave = this.normClave(art.clave);
-      const cpm = Number(art.cpm ?? this.cpmIndex.get(clave) ?? 0) || 0;
+      const cpmCapturado = Number(art.cpm ?? 0) || 0;
+      const cpm = cpmCapturado > 0 ? cpmCapturado : (this.cpmIndex.get(clave) ?? 0);
       const cantidad = Number(art.cantidad ?? 0) || 0;
 
       if (cpm <= 0) {
@@ -196,6 +198,7 @@ export class SolicitudesComponent implements OnInit, AfterViewInit, OnDestroy {
       }
 
       if (cantidad < cpm) stats.menorCpm++;
+      if (cantidad === cpm) stats.igualCpm++;
       if (cantidad > cpm) stats.mayorCpm++;
     }
 

--- a/src/app/features/solicitudes/solicitudes.component.ts
+++ b/src/app/features/solicitudes/solicitudes.component.ts
@@ -177,6 +177,31 @@ export class SolicitudesComponent implements OnInit, AfterViewInit, OnDestroy {
   cpmsDeCluesActual: CPMS[] = [];
   canEditCpms = false;
 
+  get capturaStats() {
+    const stats = {
+      total: this.articulosSolicitados.length,
+      cpmCero: 0,
+      menorCpm: 0,
+      mayorCpm: 0
+    };
+
+    for (const art of this.articulosSolicitados) {
+      const clave = this.normClave(art.clave);
+      const cpm = Number(art.cpm ?? this.cpmIndex.get(clave) ?? 0) || 0;
+      const cantidad = Number(art.cantidad ?? 0) || 0;
+
+      if (cpm <= 0) {
+        stats.cpmCero++;
+        continue;
+      }
+
+      if (cantidad < cpm) stats.menorCpm++;
+      if (cantidad > cpm) stats.mayorCpm++;
+    }
+
+    return stats;
+  }
+
   async ngOnInit() {
     if (this.router.url === '/solicitudv1') {
       this.modoStandalone = true;

--- a/src/app/features/tabla-articulos/tabla-articulos.component.html
+++ b/src/app/features/tabla-articulos/tabla-articulos.component.html
@@ -1,13 +1,14 @@
 <!-- src/app/features/tabla-articulos/tabla-articulos.component.html -->
-<div class="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+<div class="flex flex-col items-end justify-between gap-1 sm:flex-row">
   <h2 class="font-bold text-green-800">Artículos capturados</h2>
 
   @if (capturaStats) {
     <div class="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-gray-600 sm:justify-end">
-      <span>Claves solicitadas: <strong class="text-gray-800">{{ capturaStats.total }}</strong></span>
-      <span>CPM 0: <strong class="text-gray-800">{{ capturaStats.cpmCero }}</strong></span>
-      <span>&lt; CPM: <strong class="text-gray-800">{{ capturaStats.menorCpm }}</strong></span>
-      <span>&gt; CPM: <strong class="text-gray-800">{{ capturaStats.mayorCpm }}</strong></span>
+      <span>Total Solicitadas: <strong class="text-gray-800">{{ capturaStats.total }}</strong></span>
+      <span>sol. CPM 0: <strong class="text-gray-800">{{ capturaStats.cpmCero }}</strong></span>
+      <span>sol. &lt; CPM: <strong class="text-gray-800">{{ capturaStats.menorCpm }}</strong></span>
+      <span>sol. = CPM: <strong class="text-gray-800">{{ capturaStats.igualCpm }}</strong></span>
+      <span>sol. &gt; CPM: <strong class="text-gray-800">{{ capturaStats.mayorCpm }}</strong></span>
     </div>
   }
 </div>

--- a/src/app/features/tabla-articulos/tabla-articulos.component.html
+++ b/src/app/features/tabla-articulos/tabla-articulos.component.html
@@ -1,5 +1,16 @@
 <!-- src/app/features/tabla-articulos/tabla-articulos.component.html -->
-<h2 class="font-bold text-green-800">Artículos capturados</h2>
+<div class="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+  <h2 class="font-bold text-green-800">Artículos capturados</h2>
+
+  @if (capturaStats) {
+    <div class="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-gray-600 sm:justify-end">
+      <span>Claves solicitadas: <strong class="text-gray-800">{{ capturaStats.total }}</strong></span>
+      <span>CPM 0: <strong class="text-gray-800">{{ capturaStats.cpmCero }}</strong></span>
+      <span>&lt; CPM: <strong class="text-gray-800">{{ capturaStats.menorCpm }}</strong></span>
+      <span>&gt; CPM: <strong class="text-gray-800">{{ capturaStats.mayorCpm }}</strong></span>
+    </div>
+  }
+</div>
 
 <table class="mt-2 w-full text-sm">
   <thead class="text-white bg-green-600">

--- a/src/app/features/tabla-articulos/tabla-articulos.component.ts
+++ b/src/app/features/tabla-articulos/tabla-articulos.component.ts
@@ -30,7 +30,7 @@ export class TablaArticulosComponent implements OnChanges, OnInit, OnDestroy {
   @Input() cantidadTemporal: number = 0;
   @Input() inventario: InventarioDisponibles[] = [];
   @Input() cluesimbActual: string = '';
-  @Input() capturaStats: { total: number; cpmCero: number; menorCpm: number; mayorCpm: number } | null = null;
+  @Input() capturaStats: { total: number; cpmCero: number; menorCpm: number; igualCpm: number; mayorCpm: number } | null = null;
 
   cpmsDeCluesActual: CPMS[] = [];
   private cpmIndex = new Map<string, number>();

--- a/src/app/features/tabla-articulos/tabla-articulos.component.ts
+++ b/src/app/features/tabla-articulos/tabla-articulos.component.ts
@@ -30,6 +30,7 @@ export class TablaArticulosComponent implements OnChanges, OnInit, OnDestroy {
   @Input() cantidadTemporal: number = 0;
   @Input() inventario: InventarioDisponibles[] = [];
   @Input() cluesimbActual: string = '';
+  @Input() capturaStats: { total: number; cpmCero: number; menorCpm: number; mayorCpm: number } | null = null;
 
   cpmsDeCluesActual: CPMS[] = [];
   private cpmIndex = new Map<string, number>();

--- a/src/app/layout/layout/layout.component.ts
+++ b/src/app/layout/layout/layout.component.ts
@@ -95,22 +95,7 @@ export class LayoutComponent implements OnInit, OnChanges {
    * Recarga las existencias en los almacenes
    */
   refrescarInventario() {
-    // EN PRUEBA PILOTO (INVENTARIO - SAS / SACIA / SIAN )
-    const timestampFallback = localStorage.getItem('ultimaVezRefrescadoInventario');
-    const ahora = Date.now();
-    const medioDiaMs = 12 * 60 * 60 * 1000;
-
-    if (!timestampFallback ||
-      ahora - Number(timestampFallback) > medioDiaMs
-    ) {
-      // this.inventarioService.refrescarDatosInventario();
-      this.inventarioService.refrescarExistenciaAlmacenesDesdePostgres();
-      // Esperar 12 horas para refrescar inventario despues de la última vez
-      localStorage.setItem('ultimaVezRefrescadoInventario', ahora.toString());
-    } else {
-      const inventario = this.storageSolicitudService.getInventarioFromLocalStorage();
-      this.inventarioService.emitirInventario(inventario);
-    }
+    this.inventarioService.initExistenciaAlmacenes();
   }
 
   /** Sólo inventario; CPM pasa a CpmService (legacy mientras tanto) */

--- a/src/app/services/excel/dashboard-estatal-excel-exporter.ts
+++ b/src/app/services/excel/dashboard-estatal-excel-exporter.ts
@@ -23,7 +23,7 @@ export class DashboardEstatalExcelExporter {
     workbook.created = new Date();
 
     this.addResumen(workbook, payload);
-    this.addTopSheet(workbook, 'Top Faltantes', payload.topFaltantes, 'faltante');
+    this.addTopSheet(workbook, 'Faltantes CPM<1', payload.topFaltantes, 'faltante');
     this.addTopSheet(workbook, 'Top Sobreabasto', payload.topSobreabasto, 'sobreabasto');
     this.addDetalleClaves(workbook, payload);
     this.addOrdenesSheet(workbook, 'Ordenes Faltantes', payload.ordenesFaltantes);
@@ -48,7 +48,7 @@ export class DashboardEstatalExcelExporter {
     const rows: [string, string | number][] = [
       ['Fecha de generación', new Date().toLocaleString()],
       ['Ventana operativa', `${payload.windowDays} días`],
-      ['Claves en top faltantes', payload.topFaltantes.length],
+      ['Claves faltantes exportadas (CPMs eq. >= 0 y < 1)', payload.topFaltantes.length],
       ['Claves en top sobreabasto', payload.topSobreabasto.length],
       ['Piezas faltantes estimadas', this.sum(payload.topFaltantes, 'faltante_estimado')],
       ['Piezas sobreabasto estimadas', this.sum(payload.topSobreabasto, 'sobreabasto_estimado')],
@@ -139,7 +139,7 @@ export class DashboardEstatalExcelExporter {
       });
     };
 
-    addRows('Faltantes', payload.topFaltantes);
+    addRows('Faltantes CPM<1', payload.topFaltantes);
     addRows('Sobreabasto', payload.topSobreabasto);
     this.finishTable(sheet);
   }

--- a/src/app/services/inventario.service.ts
+++ b/src/app/services/inventario.service.ts
@@ -185,7 +185,6 @@ export class InventarioService {
   refrescarDatosInventario(skipLoader = true): void {
     //    console.info('🔄 InventarioService.refrescarDatosInventario() - Actualizando datos de inventario temporal...');
     this.cargandoInventarioBehaviorSubject.next(true);
-    // purgar todo el localStorage
     this.limpiarInventario();
     const url = this.apiUrl;
     this.http.get<InventarioFull>(url, skipLoader ? {
@@ -196,16 +195,8 @@ export class InventarioService {
         const inventario = this.obtenerInventarioDeBase64(response.inventario);
         const inventarioNormalizado = this.normalizarClavesInventario(inventario);
 
-        // 1) Serializar y comprimir
-        const raw = JSON.stringify(inventarioNormalizado);
-        const compressed = LZString.compress(raw);
-        try {
-          localStorage.setItem(StorageVariables.SOLICITUD_INVENTARIO, compressed);
-          localStorage.setItem(StorageVariables.SOLICITUD_INVENTARIO_TS, new Date().toISOString());
-        } catch {
-          console.warn('😱 InventarioService.refrescarDatosInventario() - localStorage lleno, omitiendo guardado');
-        }
-        // 2) Emitir
+        // Mantener el inventario de almacenes solo en memoria. Si el usuario hace F5,
+        // la app volvera a solicitar /api/inventario.
         //        console.info('✅ InventarioService.refrescarDatosInventario() - Datos del inventario temporal actualizados.');
         this.inventarioSubject.next(inventarioNormalizado as Inventario[]);
         this.cargandoInventarioBehaviorSubject.next(false);
@@ -590,27 +581,10 @@ export class InventarioService {
   }
 
   initExistenciaAlmacenes(): void {
-    const comprimido = localStorage.getItem(StorageVariables.SOLICITUD_INVENTARIO);
-    let inventario: Inventario[] = [];
+    const inventarioEnMemoria = this.inventarioSubject.getValue();
+    if (inventarioEnMemoria.length > 0) return;
 
-    if (comprimido) {
-      const raw = LZString.decompress(comprimido);
-      inventario = raw ? JSON.parse(raw) : [];
-    }
-
-    // Emitimos lo que haya en cache, aunque esté viejo, para que la UI pinte algo rápido
-    this.inventarioSubject.next(inventario);
-
-    const tsStr = localStorage.getItem(StorageVariables.SOLICITUD_INVENTARIO_TS);
-    const expired = this.isExpired(tsStr);
-    const noData = !inventario || inventario.length === 0;
-
-    if (noData || expired) {
-      // ⏱ sin datos o expirado → pegamos al nuevo endpoint PG
-      this.refrescarExistenciaAlmacenesDesdePostgres();
-    } else {
-      // console.info('✅ initInventario(): usando inventario de almacenes desde localStorage (vigente)');
-    }
+    this.refrescarDatosInventario();
   }
 
   /**


### PR DESCRIPTION

Este branch corrige la carga de existencias de almacenes en `/solicitudes`, agrega indicadores estadisticos a la tabla de articulos capturados y ajusta la exportacion de Excel del Dashboard Estatal para incluir todos los posibles faltantes con `CPMs equivalentes >= 0` y `< 1`, en lugar de exportar solo el top 10 visible.

## Cambios principales

### Solicitudes

- Se corrige la inicializacion de inventario de almacenes en `/solicitudes`.
- La carga inicial ahora usa el mismo flujo que el boton "Refrescar existencias almacenes": `InventarioService.refrescarDatosInventario()`.
- El inventario de almacenes deja de persistirse en `localStorage`.
- El inventario queda solo en memoria durante la sesion SPA.
- Si el usuario hace F5, la app vuelve a consultar `/api/inventario`.
- Se evita depender del timestamp legacy `ultimaVezRefrescadoInventario`, que podia dejar la pantalla sin invocar el endpoint aunque no hubiera inventario util.

### Tabla de articulos capturados

- Se agrega un resumen compacto junto al encabezado "Articulos capturados".
- El resumen muestra:
  - Total solicitadas
  - Solicitudes con CPM 0
  - Solicitudes menores al CPM
  - Solicitudes iguales al CPM
  - Solicitudes mayores al CPM
- El calculo usa el CPM guardado en el renglon cuando existe.
- Si el renglon trae `cpm: 0`, intenta usar el CPM vigente del indice de la unidad antes de clasificarlo como CPM 0.

### Dashboard Estatal / Resumen

- La vista conserva el top 10 en pantalla.
- La exportacion a Excel ya no usa solo el top 10 de faltantes visible.
- Para el Excel se solicita un universo amplio al backend (`limit = 10000`) y se filtra:
  - `cpms_equivalentes >= 0`
  - `cpms_equivalentes < 1`
- La hoja de faltantes se renombra a `Faltantes CPM<1`.
- El resumen del Excel aclara el nuevo criterio de exportacion.
- Se agrega una nota si el resultado alcanza el limite de 10,000 registros, porque podria requerirse un endpoint dedicado o paginado.

## Consideraciones

- La exportacion de faltantes usa `limit = 10000` como solucion practica desde frontend.
- Recomendacion futura: mover este criterio a backend con un endpoint dedicado, por ejemplo:
  - `/dashboard-estatal/faltantes?cpms_equivalentes_min=0&cpms_equivalentes_lt=1`
  - con paginacion o streaming para garantizar universo completo.
- El cambio de inventario en `/solicitudes` reduce riesgo de cache stale/corrupto en `localStorage`, pero implica una nueva llamada a `/api/inventario` despues de cada F5.
