### PR TITLE
cpm en xclave y fix de leyenda de sustitutos

### DIFF
--- a/src/app/features/dashboard-abasto/existencias/existencias-x-clave/existencias-x-clave.component.html
+++ b/src/app/features/dashboard-abasto/existencias/existencias-x-clave/existencias-x-clave.component.html
@@ -53,7 +53,13 @@
               @if (esControlado) {
                 <p class="text-red-700"> Medicamento Controlado </p>
               }
-              <p class="text-sm"> <strong>Clasif. VEN:</strong> {{ clasificacion }}</p>
+              @if (cpmEstatal > 0) {
+                <p class="text-sm">
+                  <strong>CPM estatal:</strong> {{ cpmEstatal | number:'1.0-2' }}
+                </p>
+              } @else {
+                <p class="text-sm"><strong>Sin CPM en el estado</strong></p>
+              }
               @if (citaParaDescripcionDeClave)
                 {
                 <p class="text-sm">

--- a/src/app/features/dashboard-abasto/existencias/existencias-x-clave/existencias-x-clave.component.ts
+++ b/src/app/features/dashboard-abasto/existencias/existencias-x-clave/existencias-x-clave.component.ts
@@ -10,8 +10,6 @@ import { hospitalesData } from '../../../../models/hospitalesData';
 import { AlmacenClaveResumen } from '../../../../models/almacen-clave-resumen.model';
 import { UnidadClaveResumen } from '../../../../models/unidad-clave-resumen.model';
 import { ArticulosService } from '../../../../services/articulos.service';
-import { clasificacionMedicamentosData } from '../../../../models/clasificacionMedicamentosData';
-import { ClasificadorVEN } from '../../../../models/clasificador-ven';
 import { InventarioService } from '../../../../services/inventario.service';
 import { StorageVariables } from '../../../../shared/storage-variables';
 import { Articulo } from '../../../../models/articulo-solicitud';
@@ -75,10 +73,15 @@ export class ExistenciasXClaveComponent extends AbstractTabComponent implements 
     claveFiltrada = '';
     descripcion = '';
     unidad = '';
-    clasificacion = ''; // aún no disponible
     claveConfirmada = false;
 
     datosAgrupados: AlmacenClaveResumen[] = [];
+
+    get cpmEstatal(): number {
+        return this.datosAgrupados
+            .flatMap(almacen => almacen.unidades)
+            .reduce((total, unidad) => total + Math.max(0, Number(unidad.clave.cpm) || 0), 0);
+    }
 
     autocompleteResults: any[] = [];
     moreResults = false;
@@ -193,8 +196,6 @@ export class ExistenciasXClaveComponent extends AbstractTabComponent implements 
             }
             this.descripcion = item.descripcion;
             this.unidad = item.unidadMedida ?? item.presentacion ?? '';
-            const clasificacion = clasificacionMedicamentosData.find(c => c.clave === item.clave);
-            this.clasificacion = clasificacion ? ClasificadorVEN[clasificacion.ven] : '-';
             this.autocompleteResults = [];
             this.selectedIndex = -1;
             this.cdRef.detectChanges();
@@ -242,7 +243,6 @@ export class ExistenciasXClaveComponent extends AbstractTabComponent implements 
         this.claveFiltrada = '';
         this.autocompleteResults = [];
         this.descripcion = '';
-        this.clasificacion = '';
         this.unidad = '';
         this.datosAgrupados = [];
         this.citasHalladasPorClave = [];
@@ -666,8 +666,6 @@ export class ExistenciasXClaveComponent extends AbstractTabComponent implements 
                     this.claveFiltrada = item.clave;
                     this.descripcion = item.descripcion;
                     this.unidad = item.presentacion ?? '';
-                    const clasificacion = clasificacionMedicamentosData.find(c => c.clave === item.clave);
-                    this.clasificacion = clasificacion ? ClasificadorVEN[clasificacion.ven] : '-';
                     // obtener de DASH_ABASTO_EXISTENCIAS_CITAS_X_CLAVE
                     const citasls = localStorage.getItem(StorageVariables.DASH_ABASTO_EXISTENCIAS_CITAS_X_CLAVE);
                     if (citasls) {

--- a/src/app/features/homologos-config/homologos-config.component.html
+++ b/src/app/features/homologos-config/homologos-config.component.html
@@ -2,26 +2,26 @@
   <header class="hero">
     <div>
       <p class="eyebrow">Administración</p>
-      <h1>Claves alternativas / Homólogos</h1>
+      <h1>Relaciones de sustitución</h1>
       <p class="hero-copy">
-        Administra relaciones de sustitución entre claves con búsqueda, edición rápida y seguimiento claro del catálogo.
+        Vincula claves que pueden surtirse entre sí cuando alguna no tenga existencias suficientes. Ambas claves tienen el mismo nivel dentro de la relación.
       </p>
     </div>
 
     <button type="button" class="primary-cta" (click)="openCreate()">
-      Nuevo homólogo
+      Nueva relación
     </button>
   </header>
 
-  <section class="toolbar card" aria-label="Filtros de homólogos">
+  <section class="toolbar card" aria-label="Filtros de relaciones de sustitución">
     <div class="search-block">
-      <label class="search-label" for="homologos-search">Buscar homólogos</label>
+      <label class="search-label" for="homologos-search">Buscar relaciones</label>
       <div class="search-input-wrap">
         <input
           id="homologos-search"
           class="search-input"
           type="search"
-          placeholder="Clave, descripción, sustituto o factor"
+          placeholder="Clave A, clave B, descripción o factor"
           [value]="search()"
           (input)="onSearchInput($any($event.target).value)"
         />
@@ -66,7 +66,7 @@
 
   <section class="summary-grid">
     <article class="summary-card card">
-      <span class="summary-label">Total de homologaciones</span>
+      <span class="summary-label">Total de relaciones</span>
       <strong>{{ allItems().length }}</strong>
       <small>Catálogo cargado desde la API actual.</small>
     </article>
@@ -93,8 +93,10 @@
   <section class="card listing-card" aria-labelledby="homologos-table-title">
     <div class="table-head">
       <div>
-        <h2 id="homologos-table-title">Listado de homólogos</h2>
-        <p>Ordena por columna y administra cada relación desde la misma pantalla.</p>
+        <h2 id="homologos-table-title">Claves relacionadas</h2>
+        <p>Las claves A y B pueden sustituirse entre sí; su posición no indica prioridad.
+           Para conocer las condiciones de uso y el factor de conversión, consulte con el área médica.
+        </p>
       </div>
       <span class="table-count">{{ total() }} registro(s)</span>
     </div>
@@ -102,7 +104,7 @@
     @if (loading()) {
       <div class="state-panel" role="status" aria-live="polite">
         <div class="spinner" aria-hidden="true"></div>
-        <p>Cargando homólogos...</p>
+        <p>Cargando relaciones...</p>
       </div>
     } @else if (error() && !hasRows()) {
       <div class="state-panel error-state" role="alert">
@@ -112,9 +114,9 @@
       </div>
     } @else if (!hasRows()) {
       <div class="state-panel empty-state" role="status">
-        <h3>No hay homólogos registrados</h3>
+        <h3>No hay relaciones registradas</h3>
         <p>Cuando el catálogo tenga registros aparecerán aquí para administrarlos.</p>
-        <button type="button" class="secondary-btn" (click)="openCreate()">Crear primer homólogo</button>
+        <button type="button" class="secondary-btn" (click)="openCreate()">Crear primera relación</button>
       </div>
     } @else if (total() === 0) {
       <div class="state-panel empty-state" role="status">
@@ -134,27 +136,27 @@
               </th>
               <th scope="col">
                 <button type="button" class="sort-btn" (click)="toggleSort('clave')">
-                  Clave <span class="sort-indicator">{{ sortLabel('clave') }}</span>
+                  Clave A <span class="sort-indicator">{{ sortLabel('clave') }}</span>
                 </button>
               </th>
               <th scope="col">
                 <button type="button" class="sort-btn" (click)="toggleSort('claveDescripcion')">
-                  Descripción clave <span class="sort-indicator">{{ sortLabel('claveDescripcion') }}</span>
+                  Descripción A <span class="sort-indicator">{{ sortLabel('claveDescripcion') }}</span>
                 </button>
               </th>
               <th scope="col">
                 <button type="button" class="sort-btn" (click)="toggleSort('sustituto')">
-                  Sustituto <span class="sort-indicator">{{ sortLabel('sustituto') }}</span>
+                  Clave B <span class="sort-indicator">{{ sortLabel('sustituto') }}</span>
                 </button>
               </th>
               <th scope="col">
                 <button type="button" class="sort-btn" (click)="toggleSort('sustitutoDescripcion')">
-                  Descripción sustituto <span class="sort-indicator">{{ sortLabel('sustitutoDescripcion') }}</span>
+                  Descripción B <span class="sort-indicator">{{ sortLabel('sustitutoDescripcion') }}</span>
                 </button>
               </th>
               <th scope="col">
                 <button type="button" class="sort-btn" (click)="toggleSort('factor')">
-                  Factor <span class="sort-indicator">{{ sortLabel('factor') }}</span>
+                  Factor A → B <span class="sort-indicator">{{ sortLabel('factor') }}</span>
                 </button>
               </th>
               <th scope="col" class="actions-col">Acciones</th>
@@ -178,7 +180,7 @@
                     type="button"
                     class="secondary-btn compact"
                     (click)="openEdit(row)"
-                    [attr.aria-label]="'Editar homólogo ' + row.clave + ' a ' + row.sustituto"
+                    [attr.aria-label]="'Editar relación entre ' + row.clave + ' y ' + row.sustituto"
                   >
                     Editar
                   </button>
@@ -186,7 +188,7 @@
                     type="button"
                     class="danger-btn compact"
                     (click)="requestDelete(row)"
-                    [attr.aria-label]="'Eliminar homólogo ' + row.clave + ' a ' + row.sustituto"
+                    [attr.aria-label]="'Eliminar relación entre ' + row.clave + ' y ' + row.sustituto"
                   >
                     Eliminar
                   </button>
@@ -197,7 +199,7 @@
         </table>
       </div>
 
-      <footer class="pagination" aria-label="Paginación de homólogos">
+      <footer class="pagination" aria-label="Paginación de relaciones de sustitución">
         <div class="pagination-copy">
           Mostrando {{ showingFrom() }} a {{ showingTo() }} de {{ total() }} resultados
         </div>
@@ -245,8 +247,8 @@
 
 @if (deleteTarget(); as target) {
   <app-confirmacion-modal
-    titulo="Eliminar homólogo"
-    [mensaje]="'Se eliminará la relación ' + target.clave + ' -> ' + target.sustituto + '. Esta acción no se puede deshacer.'"
+    titulo="Eliminar relación"
+    [mensaje]="'Se eliminará la relación entre ' + target.clave + ' y ' + target.sustituto + '. Esta acción no se puede deshacer.'"
     textoCancelar="Cancelar"
     [textoConfirmar]="deleting() ? 'Eliminando...' : 'Eliminar'"
     (cancelar)="cancelDelete()"

--- a/src/app/features/homologos-config/homologos-config.component.ts
+++ b/src/app/features/homologos-config/homologos-config.component.ts
@@ -112,7 +112,7 @@ export class HomologosConfigComponent {
         this.loading.set(false);
       },
       error: (err) => {
-        const message = err?.error?.error ?? 'No fue posible cargar los homólogos.';
+        const message = err?.error?.error ?? 'No fue posible cargar las relaciones.';
         this.error.set(message);
         this.loading.set(false);
       },
@@ -198,10 +198,10 @@ export class HomologosConfigComponent {
     if (this.formMode() === 'create') {
       this.api.create({ ...payload, factor }).subscribe({
         next: () => {
-          this.handleMutationSuccess('Homólogo creado correctamente.');
+          this.handleMutationSuccess('Relación creada correctamente.');
         },
         error: (err) => {
-          this.handleMutationError(err?.error?.error ?? 'No fue posible crear el homólogo.');
+          this.handleMutationError(err?.error?.error ?? 'No fue posible crear la relación.');
         },
       });
       return;
@@ -215,10 +215,10 @@ export class HomologosConfigComponent {
 
     this.api.update(id, { ...payload, factor }).subscribe({
       next: () => {
-        this.handleMutationSuccess('Homólogo actualizado correctamente.');
+        this.handleMutationSuccess('Relación actualizada correctamente.');
       },
       error: (err) => {
-        this.handleMutationError(err?.error?.error ?? 'No fue posible actualizar el homólogo.');
+        this.handleMutationError(err?.error?.error ?? 'No fue posible actualizar la relación.');
       },
     });
   }
@@ -234,16 +234,16 @@ export class HomologosConfigComponent {
       next: () => {
         this.deleting.set(false);
         this.deleteTarget.set(null);
-        this.message.set('Homólogo eliminado correctamente.');
+        this.message.set('Relación eliminada correctamente.');
         this.toast.success({
-          title: 'Homólogo eliminado',
-          content: `${target.clave} -> ${target.sustituto} fue eliminado.`,
+          title: 'Relación eliminada',
+          content: `Se eliminó la relación entre ${target.clave} y ${target.sustituto}.`,
           duration: 5,
         });
         this.loadAll();
       },
       error: (err) => {
-        const message = err?.error?.error ?? 'No fue posible eliminar el homólogo.';
+        const message = err?.error?.error ?? 'No fue posible eliminar la relación.';
         this.deleting.set(false);
         this.error.set(message);
         this.toast.error({

--- a/src/app/features/homologos-config/homologos-form-modal.component.html
+++ b/src/app/features/homologos-config/homologos-form-modal.component.html
@@ -11,12 +11,12 @@
     <div class="modal-head">
       <div>
         <h2 id="homologo-form-title">{{ title }}</h2>
-        <p>Captura la clave base, su homólogo y el factor de conversión.</p>
+        <p>Relaciona dos claves que pueden sustituirse entre sí. Su posición no establece prioridad.</p>
       </div>
       <button
         type="button"
         class="icon-btn"
-        aria-label="Cerrar formulario de homólogos"
+        aria-label="Cerrar formulario de relación de sustitución"
         (click)="cancel.emit()"
         [disabled]="saving"
       >
@@ -29,9 +29,9 @@
         <div class="field">
           <app-articulo-autocomplete
             #claveAutocomplete
-            label="Clave"
+            label="Clave A"
             inputId="homologo-clave"
-            placeholder="Buscar artículo para la clave"
+            placeholder="Buscar artículo para la clave A"
             [model]="claveControl.value"
             [required]="true"
             [invalid]="!!fieldError('clave')"
@@ -39,7 +39,7 @@
             (modelChange)="onClaveInput($event)"
             (selected)="onClaveSelected($event)"
           />
-          <p id="homologo-clave-hint" class="field-hint">Puedes escribir la clave o elegirla del autocompletado.</p>
+          <p id="homologo-clave-hint" class="field-hint">Primera clave de la relación.</p>
           @if (claveDescripcion) {
             <div class="picked ok">{{ claveDescripcion }}</div>
           }
@@ -50,9 +50,9 @@
 
         <div class="field">
           <app-articulo-autocomplete
-            label="Sustituto"
+            label="Clave B"
             inputId="homologo-sustituto"
-            placeholder="Buscar artículo homólogo"
+            placeholder="Buscar artículo para la clave B"
             [model]="sustitutoControl.value"
             [required]="true"
             [invalid]="!!fieldError('sustituto')"
@@ -60,7 +60,7 @@
             (modelChange)="onSustitutoInput($event)"
             (selected)="onSustitutoSelected($event)"
           />
-          <p id="homologo-sustituto-hint" class="field-hint">Selecciona el artículo alternativo que sustituye la clave base.</p>
+          <p id="homologo-sustituto-hint" class="field-hint">Segunda clave de la relación; puede sustituir a la clave A y viceversa.</p>
           @if (sustitutoDescripcion) {
             <div class="picked ok">{{ sustitutoDescripcion }}</div>
           }
@@ -70,7 +70,7 @@
         </div>
 
         <div class="field">
-          <label class="field-label" for="homologo-factor">Factor</label>
+          <label class="field-label" for="homologo-factor">Factor de conversión A → B</label>
           <input
             id="homologo-factor"
             class="text-input"
@@ -80,7 +80,7 @@
             aria-describedby="homologo-factor-hint homologo-factor-error"
             [attr.aria-invalid]="!!fieldError('factor')"
           />
-          <p id="homologo-factor-hint" class="field-hint">Usa números enteros o decimales según la conversión requerida.</p>
+          <p id="homologo-factor-hint" class="field-hint">Cantidad de la clave B equivalente a una unidad de la clave A.</p>
           @if (fieldError('factor'); as error) {
             <p id="homologo-factor-error" class="field-error">{{ error }}</p>
           }
@@ -90,7 +90,7 @@
       <div class="modal-actions">
         <button type="button" class="btn btn-secondary" (click)="cancel.emit()" [disabled]="saving">Cancelar</button>
         <button type="submit" class="btn btn-primary" [disabled]="saving">
-          {{ saving ? 'Guardando...' : mode === 'create' ? 'Crear homologo' : 'Guardar cambios' }}
+          {{ saving ? 'Guardando...' : mode === 'create' ? 'Crear relación' : 'Guardar cambios' }}
         </button>
       </div>
     </form>

--- a/src/app/features/homologos-config/homologos-form-modal.component.ts
+++ b/src/app/features/homologos-config/homologos-form-modal.component.ts
@@ -59,7 +59,7 @@ export class HomologosFormModalComponent implements OnChanges, AfterViewInit {
   }
 
   get title(): string {
-    return this.mode === 'create' ? 'Nuevo homologo' : 'Editar homologo';
+    return this.mode === 'create' ? 'Nueva relación de sustitución' : 'Editar relación de sustitución';
   }
 
   get claveControl() {
@@ -127,8 +127,8 @@ export class HomologosFormModalComponent implements OnChanges, AfterViewInit {
     if (!(control.touched || control.dirty) || !control.errors) return null;
 
     if (control.errors['required']) {
-      if (field === 'clave') return 'La clave es requerida.';
-      if (field === 'sustituto') return 'El sustituto es requerido.';
+      if (field === 'clave') return 'La clave A es requerida.';
+      if (field === 'sustituto') return 'La clave B es requerida.';
       return 'El factor es requerido.';
     }
 


### PR DESCRIPTION
Mejoras de usabilidad y consulta de abasto
•	Se renovó la sección de configuración de claves relacionadas para utilizar una terminología más clara y neutral.
•	Las relaciones ahora se presentan como Clave A y Clave B, sin establecer prioridad entre ellas.
•	Se aclaró que ambas claves pueden sustituirse entre sí y se indicó explícitamente la dirección del factor de conversión.
•	Se actualizaron formularios, filtros, validaciones y mensajes relacionados con esta funcionalidad.
•	En el análisis por clave se reemplazó la clasificación VEN por el CPM estatal.
•	Cuando una clave no cuenta con CPM registrado, el sistema muestra la leyenda “Sin CPM en el estado”.
Estos cambios son únicamente de presentación y consulta; no modifican la estructura actual de la base de datos.
